### PR TITLE
feat(plugins): very simple system

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,10 @@ export interface IJolocomSDKInitOptions {
   dontAutoRegister?: boolean
 }
 
+export interface JolocomPlugin {
+  register(sdk: JolocomSDK): Promise<void>
+}
+
 export class JolocomSDK extends BackendMiddleware {
   public interactionManager: InteractionManager
 
@@ -93,6 +97,11 @@ export class JolocomSDK extends BackendMiddleware {
 
       throw err
     }
+  }
+
+  async usePlugins(...plugs: JolocomPlugin[]) {
+    const promises = plugs.map(p => p.register(this))
+    await Promise.all(promises)
   }
 
   /**


### PR DESCRIPTION
plugins are expected to have a 'register' method through
which they get an instance of the SDK and are free
to hook on whatever they need from the public SDK API