### PR TITLE
docs(typos): fix incorrect names in docs

### DIFF
--- a/docs/md_book/docs/agents.md
+++ b/docs/md_book/docs/agents.md
@@ -46,10 +46,10 @@ In case the desired functionality is to register the identity regardless of whet
 
 ## Loading an existing identity
 
-To provision the Agent with a previously created identity, the following function can be used:
+To instantiate an Agent with a previously created identity, the following function can be used:
 
 ```typescript
-sdk.loadIdentity('demoPassword', 'did:jolo:aaa...fff')
+sdk.loadAgent('demoPassword', 'did:jolo:aaa...fff')
 ```
 
 If a DID is provided, the method will attempt to find the associated encrypted wallet / DID Document entries using the `storage` interface. In case no entries have been found, an error is thrown. In case no argument is provided to the function, the first identity found is used.

--- a/docs/md_book/docs/interaction_flows.md
+++ b/docs/md_book/docs/interaction_flows.md
@@ -166,7 +166,7 @@ In this simple example, Alice is issuing Bob the Credential she created for him 
 Alice creates a Credential Offer:
 
 ```typescript
-const aliceCredOffer = await alice.credentialOffer({
+const aliceCredOffer = await alice.credOfferToken({
   callbackURL: 'https://example.com/issuance',
   offeredCredentials: [
     {
@@ -226,7 +226,7 @@ Alice creates a Credential Offer:
 ```typescript
 import { JolocomLib } from '@jolocom/sdk'
 
-const aliceCredRequest = await alice.credentialRequestToken({
+const aliceCredRequest = await alice.credRequestToken({
   callbackURL: 'https://example.com/request',
   credentialRequirements: [
     {


### PR DESCRIPTION
some function names and such are currently incorrect