### PR TITLE
fix: don't require 'ws'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,12 +70,16 @@ export class JolocomSDK {
     } catch (err) {
       // pass, it's ok
     }
+    /*
+     * Note this is disabled because it breaks metro bundler
+     *
     try {
       const WebSocket = require('ws')
       this.transports.ws.configure({ WebSocket })
     } catch (err) {
       // pass, it's ok
     }
+    */
   }
 
   /**

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -31,8 +31,9 @@ const testWsEndpoint = `ws://127.0.0.1:${testPort}`
 let serviceChanPromise: Promise<Channel>
 
 beforeEach(async () => {
-  // Create a user Agent and register a WebSockets transport type handler
+  // Create a user Agent and configure WebSockets transport handler
   user = await createAgent(conn1Name)
+  user.sdk.transports.ws.configure({ WebSocket })
   await user.createNewIdentity()
 
   // Create a service agent, and start a WebSockets server


### PR DESCRIPTION
because it breaks metro bundler