### PR TITLE
Feat/77/continuation

### DIFF
--- a/src/channels/channel.ts
+++ b/src/channels/channel.ts
@@ -61,11 +61,11 @@ export class Channel extends Transportable {
     return flowState.established
   }
 
-  public getSummary(): ChannelSummary {
-    const interactions = this._threadIdList.map((qId: string) => {
-      const interxn = this.ctx.ctx.interactionManager.getInteraction(qId)
+  public async getSummary(): Promise<ChannelSummary> {
+    const interactions = await Promise.all(this._threadIdList.map(async (qId: string) => {
+      const interxn = await this.ctx.ctx.interactionManager.getInteraction(qId)
       return interxn && interxn.getSummary()
-    })
+    }))
 
     return {
       initialInteraction: this.initialInteraction.getSummary(),

--- a/src/channels/channelKeeper.ts
+++ b/src/channels/channelKeeper.ts
@@ -34,7 +34,7 @@ export class ChannelKeeper {
   }
 
   async findByJWT(jwt: string) {
-    const interxn = this.ctx.findInteraction(jwt)
+    const interxn = await this.ctx.findInteraction(jwt)
     const chId = interxn && interxn.flow.type === FlowType.EstablishChannel
       ? interxn.id
       : ''

--- a/src/interactionManager/interaction.ts
+++ b/src/interactionManager/interaction.ts
@@ -130,6 +130,40 @@ export class Interaction<F extends Flow<any> = Flow<any>> extends Transportable 
     this.flow = new interactionFlowForMessage[interactionType](this)
   }
 
+  static async fromMessages(
+    messages: Array<JSONWebToken<any>>,
+    ctx: InteractionManager,
+    id: string,
+    transportAPI?: TransportAPI
+  ): Promise<Interaction> {
+    if (messages.length === 0) {
+      throw new SDKError(ErrorCode.InvalidToken)
+    }
+
+    // instantiate
+    const interaction = new Interaction(ctx, id, messages[0].interactionType, transportAPI)
+
+    // set message history
+    interaction.messages = messages
+
+    // set participants
+    interaction.participants.requester = await ctx.ctx.resolve(messages[0].issuer)
+
+    if (messages[1]) interaction.participants.responder = await ctx.ctx.resolve(messages[1].issuer)
+
+    // set role
+    if (messages[0].issuer === ctx.ctx.idw.did) interaction.role = InteractionRole.Requester
+    else if (messages[1].issuer === ctx.ctx.idw.did) interaction.role = InteractionRole.Responder
+
+    // replay history to get current state
+    for (let message of messages) {
+      await interaction.flow.onValidMessage(message.interactionToken, message.interactionType)
+    }
+
+    // return
+    return interaction
+  }
+
   get firstMessage() {
     if (this.messages.length < 1) throw new Error('Empty interaction')
     return this.messages[0]

--- a/src/interactionManager/interactionManager.ts
+++ b/src/interactionManager/interactionManager.ts
@@ -18,7 +18,7 @@ import { TransportAPI } from '../types'
  *
  * @category Interactions
  */
-export class InteractionManager{
+export class InteractionManager {
   public readonly ctx: Agent
 
   public interactions: {
@@ -45,9 +45,7 @@ export class InteractionManager{
     return interaction
   }
 
-  // FIXME this can return UNDEFINED, should throw an error
-  // FIXME need to be async to support storage backends
-  public getInteraction<F extends Flow<any> = Flow<any>>(id: string) {
-    return this.interactions[id] as Interaction<F>
+  public async getInteraction<F extends Flow<any>>(id: string, transportAPI?: TransportAPI): Promise<Interaction<F>> {
+    return await Interaction.fromMessages<F>(await this.ctx.storage.get.interactionTokens({ nonce: id }), this, id, transportAPI)
   }
 }

--- a/tests/authRequest.test.ts
+++ b/tests/authRequest.test.ts
@@ -31,11 +31,11 @@ test('Authentication interaction', async () => {
   const bobResponse = (
     await bobInteraction.createAuthenticationResponse()
   ).encode()
-  await bob.processJWT(bobResponse)
+  const bobNewInteraction = await bob.processJWT(bobResponse)
 
   const aliceInteraction = await alice.processJWT(bobResponse)
 
   expect(aliceInteraction.getMessages().map(m => m.encode())).toEqual(
-    bobInteraction.getMessages().map(m => m.encode()),
+    bobNewInteraction.getMessages().map(m => m.encode()),
   )
 })

--- a/tests/channels.test.ts
+++ b/tests/channels.test.ts
@@ -108,7 +108,7 @@ test('Establish a channel', async () => {
     description: "test"
   })
   const resp = await serviceChan.startThread(authReq)
-  const interxn = service.findInteraction(resp)
-  const userAuthInterxn = user.findInteraction(resp)
+  const interxn = await service.findInteraction(resp)
+  const userAuthInterxn = await user.findInteraction(resp)
   expect(interxn!.flow.state).toEqual(userAuthInterxn!.flow.state)
 })


### PR DESCRIPTION
Adds method to instantiate `Interaction`s using a list of messages and moves primary storage of `Interaction`s to storage (refactors `getInteraction` to use storage). Implements #77, but has a breaking change in the `Channel` API (`getSummary` is now `async`)