### PR TITLE
Refactor Interactions to enable loading historical Interactions

### DIFF
--- a/src/interactionManager/interactionManager.ts
+++ b/src/interactionManager/interactionManager.ts
@@ -42,6 +42,7 @@ export class InteractionManager {
     )
     this.interactions[token.nonce] = interaction
     await interaction.processInteractionToken(token)
+    await this.ctx.storage.store.interactionToken(token)
 
     return interaction
   }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -88,6 +88,17 @@ describe('findInteraction', () => {
   })
 
   describe('reconstructing an interaction from stored messages', () => {
+    it('returns an interaction even if already expired', async () => {
+      jest.useFakeTimers('modern')
+      jest.setSystemTime(0)
+      const jwt = await alice.authRequestToken({ callbackURL: 'dummy', description: 'test' })
+      jest.useRealTimers()
+      const alice2 = await alice.sdk.initAgent({})
+      const interxn = await alice2.findInteraction(jwt.nonce)
+
+      expect(() => interxn.transportAPI).not.toThrow()
+    })
+
     it('returns an interaction that has a transportAPI', async () => {
       const jwt = await alice.authRequestToken({ callbackURL: 'dummy', description: 'test' })
 

--- a/tests/authRequest.test.ts
+++ b/tests/authRequest.test.ts
@@ -27,6 +27,7 @@ test('Authentication interaction', async () => {
   })
 
   const bobInteraction = await bob.processJWT(aliceAuthRequest.encode())
+  expect(() => bobInteraction.transportAPI).not.toThrow()
 
   const bobResponse = (
     await bobInteraction.createAuthenticationResponse()

--- a/tests/credIssuance.test.ts
+++ b/tests/credIssuance.test.ts
@@ -39,6 +39,7 @@ test('Credential Issuance interaction', async () => {
   })
 
   const bobInteraction = await bob.processJWT(aliceCredOffer.encode())
+  expect(() => bobInteraction.transportAPI).not.toThrow()
 
   const bobResponse = (
     await bobInteraction.createCredentialOfferResponseToken([

--- a/tests/credRequest.test.ts
+++ b/tests/credRequest.test.ts
@@ -49,6 +49,7 @@ test('Credential Request interaction', async () => {
   })
 
   const bobInteraction = await bob.processJWT(aliceCredReq.encode())
+  expect(() => bobInteraction.transportAPI).not.toThrow()
 
   const bobResponse = (
     await bobInteraction.createCredentialResponse([bobSelfSignedCred.id])


### PR DESCRIPTION
`agent.processJWT` is now responsible for ~validating incoming JWTs,~ storing JWTs as necessary, and "encountering" new DIDs based on `jwt.payload.pca`
`Interaction.processInteractionToken` need not concern itself with those, and can remain rather "pure"

This PR does not affect the public API's inputs/outputs, but does affect behavior: if someone was directly using `Interaction.processInteractionToken` then they should now also handle the storage ~and validation~ concerns
