### PR TITLE
Fix Flow.type type and make processJWT accept JSONWebToken

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -317,15 +317,15 @@ export class Agent {
    * Parses a recieved interaction token in JWT format and process it through
    * the interaction system, returning the corresponding Interaction
    *
-   * @param jwt recieved jwt string
+   * @param jwt recieved jwt string or parsed JSONWebToken
    * @returns Promise<Interaction> the associated Interaction object
    * @throws AppError<InvalidToken> with `origError` set to the original token
    *                                validation error from the jolocom library
    *
    * @category Interaction Management
    */
-  public async processJWT(jwt: string, transportAPI?: TransportAPI): Promise<Interaction> {
-    const token = JolocomLib.parse.interactionToken.fromJWT(jwt)
+  public async processJWT(jwt: JSONWebToken<any> | string, transportAPI?: TransportAPI): Promise<Interaction> {
+    const token = typeof jwt === 'string' ? JolocomLib.parse.interactionToken.fromJWT(jwt) : jwt
     let interxn
 
     try {

--- a/src/interactionManager/flow.ts
+++ b/src/interactionManager/flow.ts
@@ -16,7 +16,7 @@ export abstract class Flow<T> {
     this.ctx = ctx
   }
 
-  get type() {
+  get type(): FlowType {
     // @ts-ignore
     return this.constructor.type
   }


### PR DESCRIPTION
Miscellaneous fixes.

- `Flow.type` accidentally became `any`
- `agent.processJWT` now handles storing tokens and should be used instead of directly calling `interxn.processInteractionToken`
  so it should also accept parsed `JSONWebToken` objects, and not just encoded once (strings)