### PR TITLE
Credentials API on SDK/Agent

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,15 @@
 require('@jolocom/native-core')
+const { pathsToModuleNameMapper } = require('ts-jest/utils')
+
+//const { compilerOptions } = require('./tsconfig')
+const compilerOptions = {
+  paths: {
+    // this is needed so that we can use a yarn linked sdk-storage-typeorm in
+    // our tests, otherwise it imports its own sdk/lib from its node_modules
+      "@jolocom/sdk": ["<rootDir>/src"],
+      "jolocom-lib/*": ["<rootDir>/node_modules/jolocom-lib/*"],
+  }
+}
 module.exports = {
   preset: 'ts-jest',
   globals: {
@@ -7,5 +18,9 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'node', 'js', 'json'],
   testMatch: ['**/tests/*.test.ts'],
-  testPathIgnorePatterns: ['/node_modules/.*']
+  testPathIgnorePatterns: ['/node_modules/.*'],
+  moduleNameMapper: pathsToModuleNameMapper(
+    compilerOptions.paths,
+   // { prefix: '<rootDir>/' }
+  )
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typeorm": "ts-node -O '{\"module\": \"commonjs\"}' -r ./bin/repl.ts node_modules/.bin/typeorm",
     "lint": "eslint --ext .ts --ext .tsx .",
     "format": "yarn lint --fix",
-    "test": "node --async-stack-traces node_modules/.bin/jest --coverage --collectCoverageFrom=src/**/*.ts --coverageDirectory=coverage",
+    "test": "jest --coverage --collectCoverageFrom=src/**/*.ts --coverageDirectory=coverage",
     "docs": "./bin/build_docs.sh",
     "docs:serve": "./bin/build_docs.sh serve"
   },
@@ -25,7 +25,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime": "^7.11.2",
     "@jolocom/local-resolver-registrar": "^1.0.1",
-    "@jolocom/sdk-storage-typeorm": "^4.1.0",
+    "@jolocom/sdk-storage-typeorm": "^4.2.0",
     "@types/jest": "^26.0.10",
     "@types/node": "^13.9.8",
     "@types/node-fetch": "^2.5.5",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     "build": "rm -rf js && tsc --rootDir src -p .",
     "prepare": "yarn build",
-    "repl": "node --experimental-repl-await -r ts-node/register ./bin/repl.ts",
+    "repl": "node --experimental-repl-await -r tsconfig-paths/register -r ts-node/register ./bin/repl.ts",
     "typeorm": "ts-node -O '{\"module\": \"commonjs\"}' -r ./bin/repl.ts node_modules/.bin/typeorm",
     "lint": "eslint --ext .ts --ext .tsx .",
     "format": "yarn lint --fix",
-    "test": "jest --coverage --collectCoverageFrom=src/**/*.ts --coverageDirectory=coverage",
+    "test": "node --async-stack-traces node_modules/.bin/jest --coverage --collectCoverageFrom=src/**/*.ts --coverageDirectory=coverage",
     "docs": "./bin/build_docs.sh",
     "docs:serve": "./bin/build_docs.sh serve"
   },
@@ -53,6 +53,7 @@
     "ts-jest": "^26.3.0",
     "ts-loader": "3.5.0",
     "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
     "tslib": "^1.7.1",
     "typedoc": "^0.19.2",
     "typeorm": "0.2.24",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -30,16 +30,16 @@ import {
   ICredentialRequestAttrs,
   CredentialOfferRequestAttrs,
   ICredentialsReceiveAttrs,
+  BaseMetadata,
+  ISignedCredCreationArgs,
 } from '@jolocom/protocol-ts'
-import { BaseMetadata } from '@jolocom/protocol-ts'
-import { ISignedCredCreationArgs } from 'jolocom-lib/js/credentials/signedCredential/types'
 import { Flow } from './interactionManager/flow'
 import { Identity } from 'jolocom-lib/js/identity/identity'
 import { CredentialRequest } from 'jolocom-lib/js/interactionTokens/credentialRequest'
 import { CredentialOfferRequest } from 'jolocom-lib/js/interactionTokens/credentialOfferRequest'
 import { CredentialsReceive } from 'jolocom-lib/js/interactionTokens/credentialsReceive'
 import { Authentication } from 'jolocom-lib/js/interactionTokens/authentication'
-import { CredentialType } from './credentials'
+import { CredentialType, CredentialIssuer } from './credentials'
 
 /**
  * The `Agent` class mainly provides an abstraction around the {@link
@@ -81,6 +81,8 @@ export class Agent {
   public resolver: IResolver
   public storage: IStorage
 
+  public credentials: CredentialIssuer
+
   public constructor({
     sdk,
     passwordStore,
@@ -96,6 +98,9 @@ export class Agent {
     this.resolve = this.sdk.resolve.bind(this.sdk)
     this.resolver = this.sdk.resolver
     this.storage = this.sdk.storage
+    this.credentials = new CredentialIssuer(this, () => {
+      return { subject: this.identityWallet.did }
+    })
   }
 
   /**
@@ -637,14 +642,12 @@ export class Agent {
    * @param credParams - credential attributes
    * @returns SignedCredential instance
    * @category Credential Management
+   * @deprecated
    */
   public async signedCredential<T extends BaseMetadata>(
     credParams: ISignedCredCreationArgs<T>,
   ) {
-    return await this.idw.create.signedCredential(
-      credParams,
-      await this.passwordStore.getPassword(),
-    )
+    return this.credentials.issue(credParams)
   }
 
   /**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -39,7 +39,7 @@ import { CredentialRequest } from 'jolocom-lib/js/interactionTokens/credentialRe
 import { CredentialOfferRequest } from 'jolocom-lib/js/interactionTokens/credentialOfferRequest'
 import { CredentialsReceive } from 'jolocom-lib/js/interactionTokens/credentialsReceive'
 import { Authentication } from 'jolocom-lib/js/interactionTokens/authentication'
-import { CredentialType, CredentialIssuer } from './credentials'
+import { CredentialIssuer } from './credentials'
 
 /**
  * The `Agent` class mainly provides an abstraction around the {@link
@@ -523,10 +523,19 @@ export class Agent {
           ...oc.issuer
         }
         if (oc.credential) {
-          const credType = new CredentialType(oc.type, oc.credential)
-          oc = credType.onCreateOffer(oc)
+          // NOTE: currently CredentialOffer assumes a fixed value of the type array
+          const credentialDefaults = { schema: '', name: oc.type }
+          return {
+            ...oc,
+            credential: {
+              ...credentialDefaults,
+              ...oc.credential,
+              ...oc.credential,
+            },
+          }
+        } else {
+          return oc
         }
-        return oc
       }),
     }, await this.passwordStore.getPassword())
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -3,8 +3,17 @@ import {
   CredentialOffer,
   CredentialManifestDisplayMapping,
   ClaimEntry,
-} from "@jolocom/protocol-ts"
-import { jsonpath } from "./util"
+  BaseMetadata,
+  ISignedCredCreationArgs,
+  ISignedCredentialAttrs,
+} from '@jolocom/protocol-ts'
+import { jsonpath } from './util'
+import { QueryOptions, IStorage, CredentialQuery } from './storage'
+import { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'
+import { Agent } from './agent'
+import { ObjectKeeper } from './types'
+import { IResolver } from 'jolocom-lib/js/didMethods/types'
+import { validateJsonLd } from 'jolocom-lib/js/linkedData'
 
 export interface DisplayVal {
   label?: string
@@ -16,7 +25,7 @@ export interface CredentialDisplay {
   type: string
   name: string
   schema: string
-  styles: CredentialDefinition["styles"]
+  styles: CredentialDefinition['styles']
   display: {
     properties: DisplayVal[]
     title?: DisplayVal
@@ -37,7 +46,7 @@ export class CredentialType {
 
   display(claim: ClaimEntry): CredentialDisplay {
     const display: CredentialDisplay['display'] = {
-      properties: []
+      properties: [],
     }
 
     if (this.def.display) {
@@ -45,9 +54,7 @@ export class CredentialType {
         const val = this.def.display![k]
         if (Array.isArray(val)) {
           // it's the 'properties' array
-          display[k] = val.map((dm) =>
-            this._processDisplayMapping(dm, claim)
-          )
+          display[k] = val.map((dm) => this._processDisplayMapping(dm, claim))
         } else {
           // one of 'title', 'subtitle', 'description'
           display[k] = this._processDisplayMapping(val, claim)
@@ -58,7 +65,7 @@ export class CredentialType {
     return {
       type: this.type,
       name: this.def.name || this.type,
-      schema: this.def.schema || "",
+      schema: this.def.schema || '',
       display: display,
       styles: {
         ...this.def.styles,
@@ -68,7 +75,7 @@ export class CredentialType {
 
   private _processDisplayMapping(
     dm: CredentialManifestDisplayMapping,
-    claim: any
+    claim: any,
   ) {
     let value
     const key = claim
@@ -87,7 +94,7 @@ export class CredentialType {
   }
 
   onCreateOffer(offer: CredentialOffer): CredentialOffer {
-    const credentialDefaults = { schema: "", name: offer.type }
+    const credentialDefaults = { schema: '', name: offer.type }
     return {
       ...offer,
       credential: {
@@ -97,4 +104,116 @@ export class CredentialType {
       },
     }
   }
+}
+
+export class CredentialKeeper
+  implements
+    ObjectKeeper<
+      SignedCredential,
+      ISignedCredCreationArgs<any>,
+      CredentialQuery
+    > {
+  protected storage: IStorage
+  protected resolver: IResolver
+  private _applyFilter: () => CredentialQuery | undefined
+
+  constructor(
+    storage: IStorage,
+    resolver: IResolver,
+    filter?: CredentialQuery | (() => CredentialQuery),
+  ) {
+    this.storage = storage
+    this.resolver = resolver
+    this._applyFilter = typeof filter === 'function' ? filter : () => filter
+  }
+
+  /**
+   * Retrieves a Signed Credential by id, or throws
+   *
+   * @param credParams - credential attributes
+   * @returns SignedCredential instance
+   * @category Credential Management
+   */
+  async get(id: string): Promise<SignedCredential> {
+    const creds = await this.query({ id })
+    if (creds.length !== 1)
+      throw new Error('multiple results for cred id ' + id)
+    return creds[0]
+  }
+
+  async query(attrs?: CredentialQuery, options?: QueryOptions): Promise<SignedCredential[]> {
+    const filterVals = this._applyFilter()
+    return await this.storage.get.verifiableCredential({
+      ...attrs,
+      ...filterVals,
+    })
+  }
+
+  async delete(attrs?: CredentialQuery) {
+    // we use this.find to apply the filter if any
+    const creds = await this.query(attrs)
+    if (creds.length === 0) return false
+
+    await creds.map(({ id }) => this.storage.delete.verifiableCredential(id))
+    return true
+  }
+
+  async getCredentialType(cred: SignedCredential): Promise<CredentialType> {
+    const vcType = cred.type[1]
+    const metadata = await this.storage.get.credentialMetadata(cred)
+    return new CredentialType(
+      vcType,
+      metadata?.credential || ({} as CredentialDefinition),
+    )
+  }
+
+  async display(cred: SignedCredential): Promise<CredentialDisplay> {
+    const credType = await this.getCredentialType(cred)
+    return credType.display(cred.claim)
+  }
+
+  async verify(
+    cred: SignedCredential | ISignedCredentialAttrs,
+  ): Promise<boolean> {
+    const issuer = await this.resolver.resolve(cred.issuer)
+    const json = cred instanceof SignedCredential ? cred.toJSON() : cred
+    return validateJsonLd(json, issuer)
+  }
+}
+
+export class CredentialIssuer extends CredentialKeeper {
+  private agent: Agent
+
+  constructor(
+    agent: Agent,
+    filter?: CredentialQuery | (() => CredentialQuery),
+  ) {
+    super(agent.storage, agent.resolver, filter)
+    this.agent = agent
+  }
+
+  /**
+   * Creates and signs a Credential, and commits it to storage.
+   *
+   * @param credParams - credential attributes
+   * @returns SignedCredential instance
+   * @category Credential Management
+   */
+  async create<T extends BaseMetadata>(credParams: ISignedCredCreationArgs<T>) {
+    const cred = await this.agent.idw.create.signedCredential(
+      credParams,
+      await this.agent.passwordStore.getPassword(),
+    )
+
+    // FIXME TODO: issuers currently can't store the cred in their DB because it
+    // requires a foreign link to the subject... so only self-signed creds work
+    // Otherwise it throws
+    if (cred.issuer === cred.subject) {
+      await this.storage.store.verifiableCredential(cred)
+    }
+
+    return cred
+  }
+
+  issue = this.create
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { SoftwareKeyProvider } from 'jolocom-lib'
 import { SDKError, ErrorCode } from './errors'
 export { SDKError, ErrorCode }
 
-import { IStorage, IPasswordStore, InteractionQueryAttrs } from './storage'
+import { IStorage, IPasswordStore } from './storage'
 export { NaivePasswordStore } from './storage'
 export { JolocomLib } from 'jolocom-lib'
 export { JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { SoftwareKeyProvider } from 'jolocom-lib'
 import { SDKError, ErrorCode } from './errors'
 export { SDKError, ErrorCode }
 
-import { IStorage, IPasswordStore } from './storage'
+import { IStorage, IPasswordStore, InteractionQueryAttrs } from './storage'
 export { NaivePasswordStore } from './storage'
 export { JolocomLib } from 'jolocom-lib'
 export { JSONWebToken } from 'jolocom-lib/js/interactionTokens/JSONWebToken'
@@ -13,6 +13,7 @@ import { IResolver } from 'jolocom-lib/js/didMethods/types'
 import { Identity } from 'jolocom-lib/js/identity/identity'
 import { Agent } from './agent'
 import { TransportKeeper } from './transports'
+import { CredentialKeeper } from './credentials'
 export { Agent } from './agent'
 
 export * from './types'
@@ -40,6 +41,7 @@ export class JolocomSDK {
   public didMethods = new DidMethodKeeper()
   public transports = new TransportKeeper()
   public storage: IStorage
+  public credentials: CredentialKeeper
 
   /**
    * The toplevel resolver which simply invokes {@link resolve}
@@ -58,6 +60,8 @@ export class JolocomSDK {
     // FIXME the prefix bit is required just to match IResolver
     // but does anything need it at that level?
     this.resolver = { prefix: '', resolve: this.resolve.bind(this) }
+
+    this.credentials = new CredentialKeeper(this.storage, this.resolver)
 
     // if we are running on NodeJS, then autoconfig some things if possible
     if (process && process.version) this._autoconfigForNodeJS()
@@ -98,7 +102,7 @@ export class JolocomSDK {
         .getForDid(did)
         .resolver.resolve(did)
 
-      await this.storage.store.identity(resolved).catch(err => {
+      await this.storage.store.identity(resolved).catch((err) => {
         console.error('Failed to store Identity after resolving', err)
       })
 

--- a/src/interactionManager/interaction.ts
+++ b/src/interactionManager/interaction.ts
@@ -60,6 +60,7 @@ import { generateIdentitySummary } from '../util'
 import { last } from 'ramda'
 import { TransportAPI, TransportDesc, InteractionTransportType } from '../types'
 import { Transportable } from '../transports'
+import { CredentialQuery } from 'src/storage'
 
 export const flows = [
   AuthenticationFlow,
@@ -608,17 +609,13 @@ export class Interaction<F extends Flow<any> = Flow<any>> extends Transportable 
     }
   }
 
-  public async getAttributesByType(type: string[]) {
-    return this.ctx.ctx.storage.get.attributesByType(type)
-  }
-
   public async getStoredCredentialById(id: string) {
     return this.ctx.ctx.storage.get.verifiableCredential({
       id,
     })
   }
 
-  public async getVerifiableCredential(query?: object) {
+  public async getVerifiableCredential(query?: CredentialQuery) {
     return this.ctx.ctx.storage.get.verifiableCredential(query)
   }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -16,6 +16,23 @@ export interface EncryptedWalletAttributes {
   timestamp: number
 }
 
+export interface CredentialQueryAttrs {
+  id?: string
+  issuer?: string
+  subject?: string
+  type?: string[]
+
+  /*
+   * TODO
+  types?: string[][]
+  claim?: {
+    [key: string]: string | number | boolean | JsonLdObject | JsonLdObject[]
+  }
+  */
+}
+
+export type CredentialQuery = CredentialQueryAttrs | CredentialQueryAttrs[]
+
 export interface QueryOptions {
   skip?: number
   take?: number
@@ -46,14 +63,15 @@ export interface InteractionTokenAttrs {
   type?: string
   issuer?: string
 }
+export type InteractionTokenQuery = InteractionTokenAttrs | InteractionTokenAttrs[]
 
 export interface IStorageGet {
   settingsObject(): Promise<{ [key: string]: any }>
   setting(key: string): Promise<any>
-  verifiableCredential(query?: object, options?: QueryOptions): Promise<SignedCredential[]>
-  // FIXME types
-  attributesByType(type: string[]): Promise<{ type: string[]; results: any[] }>
-  vCredentialsByAttributeValue(attribute: string, options?: QueryOptions): Promise<SignedCredential[]>
+  verifiableCredential(
+    query?: CredentialQuery,
+    options?: QueryOptions,
+  ): Promise<SignedCredential[]>
   encryptedWallet(id?: string): Promise<EncryptedWalletAttributes | null>
   credentialMetadata(
     credential: SignedCredential,
@@ -61,11 +79,11 @@ export interface IStorageGet {
   publicProfile(did: string): Promise<IdentitySummary>
   identity(did: string): Promise<Identity | undefined>
   interactionTokens(
-    attrs?: InteractionTokenAttrs,
+    query?: InteractionTokenQuery,
     options?: QueryOptions,
   ): Promise<Array<JSONWebToken<any>>>
   interactionIds(
-    attrs?: InteractionTokenAttrs | InteractionTokenAttrs[],
+    query?: InteractionTokenQuery,
     options?: QueryOptions,
   ): Promise<Array<string>>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { PublicProfileClaimMetadata } from '@jolocom/protocol-ts'
+import { PublicProfileClaimMetadata, CredentialDefinition } from '@jolocom/protocol-ts'
 import { CredentialOfferRenderInfo, CredentialOfferMetadata } from 'jolocom-lib/js/interactionTokens/types'
 import { QueryOptions } from './storage'
 
@@ -25,6 +25,7 @@ export interface CredentialMetadata {
   type: string
   renderInfo?: CredentialOfferRenderInfo
   metadata?: CredentialOfferMetadata
+  credential?: CredentialDefinition
 }
 
 /**

--- a/tests/credIssuance.test.ts
+++ b/tests/credIssuance.test.ts
@@ -90,7 +90,7 @@ test('Credential Issuance interaction', async () => {
   const aliceInteraction = await alice.processJWT(bobResponse)
 
   const aliceIssuance = await aliceInteraction.createCredentialReceiveToken([
-    await alice.signedCredential({
+    await alice.credentials.issue({
       metadata: claimsMetadata.name,
       subject: bob.idw.did,
       claim: {
@@ -100,7 +100,7 @@ test('Credential Issuance interaction', async () => {
     }),
   ])
 
-  const bobRecieving = await bob.processJWT(aliceIssuance.encode())
+  const bobRecieving = await bob.processJWT(aliceIssuance)
   const bobsFlow = bobRecieving.flow as CredentialOfferFlow
   expect(bobsFlow.state.credentialsAllValid).toBeTruthy()
 
@@ -110,6 +110,9 @@ test('Credential Issuance interaction', async () => {
     invalidIssuer: false,
     invalidSubject: false
   })
+  await expect(bob.credentials.query()).resolves.toHaveLength(0)
+  await bobRecieving.storeSelectedCredentials()
+  await expect(bob.credentials.query()).resolves.toHaveLength(1)
 })
 
 test('Credential Issuance interaction, with out of order selection and invalid credential', async () => {

--- a/tests/credRequest.test.ts
+++ b/tests/credRequest.test.ts
@@ -30,7 +30,7 @@ test('Credential Request interaction', async () => {
   )
 
   // Bob self-issues a name credential
-  const bobSelfSignedCred = await bob.signedCredential({
+  const bobSelfSignedCred = await bob.credentials.issue({
     metadata: claimsMetadata.name,
     subject: bob.idw.did,
     claim: {
@@ -38,8 +38,6 @@ test('Credential Request interaction', async () => {
       familyName: 'Agent',
     },
   })
-
-  await bob.storage.store.verifiableCredential(bobSelfSignedCred)
 
   const aliceCredReq = await alice.credRequestToken({
     callbackURL: 'nowhere',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { destroyAgent, getSdk } from "./util"
-import { JolocomSDK } from "src"
-import { CredentialOfferFlowState } from "src/interactionManager/types"
+import { JolocomSDK } from "../src"
+import { CredentialOfferFlowState } from "../src/interactionManager/types"
 
 const connName = "test"
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["../src/**/*", "./**/*"]
+  "include": ["../src/**/*", "./**/*"],
+  "compilerOptions": {
+    "paths": {
+      "@jolocom/sdk": ["../src/"]
+    }
+  }
 }

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -35,6 +35,7 @@ export const getConnectionConfig = (name: string) => ({
   name,
   type: 'sqlite',
   database: ':memory:',
+  //database: `./${name}.test.db.sqlite3`, // to save the test databases
   dropSchema: true,
   entities: ['node_modules/@jolocom/sdk-storage-typeorm/js/src/entities/*.js'],
   synchronize: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,11 @@
     "suppressImplicitAnyIndexErrors": true,
     "noEmitHelpers": true,
     "skipLibCheck": true,
+
+    "paths": {
+      // NOTE: paths need to be reflected in jest.config.js and tests/tsconfig.json
+      "@jolocom/sdk": ["./src"]
+    }
   },
   "exclude": [],
   "include": ["./src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,6 +1678,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/node-fetch@^2.5.5":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -6626,6 +6631,11 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -6882,6 +6892,16 @@ ts-toolbelt@^6.3.3:
   version "6.15.5"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
   integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,10 +1552,10 @@
   dependencies:
     ethers "5.0.5"
 
-"@jolocom/sdk-storage-typeorm@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jolocom/sdk-storage-typeorm/-/sdk-storage-typeorm-4.1.0.tgz#008ddad8756e39cdd37b9c6c6ecea9fa9fee0a38"
-  integrity sha512-OxyGGk6D5DxSoAWmaNZSvGyyEkuLnbxLTnILuVJPbq1WGxUjKaqIoI/U6bfyIy+2DcL0mZflClkGaiQoIENkbA==
+"@jolocom/sdk-storage-typeorm@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jolocom/sdk-storage-typeorm/-/sdk-storage-typeorm-4.2.0.tgz#bcb559e2cbbf4246d302efb05778cb6e6d5bd7c1"
+  integrity sha512-LBmxfHBp8+ddOw/+Mbu3OU9mXoWuQhZQynl/eDkQ1VE0C0CJXTPrQ2g9LqzCHiwiAvOXajfnhb0l48+9awjydg==
   dependencies:
     class-transformer "^0.3.1"
     ramda "^0.27.1"


### PR DESCRIPTION
This adds `CredentialKeeper` and `CredentialIssuer` classes, and instances of them on the `sdk` and `agent`.
They can be used as `sdk.credentials.get`, `create`/`issue`, `query`, `delete`, and also similarly on the `agent`
On the agent, the credentials scope is limited to those whose subject is the agent (need to also add support for checking for issuer!)

This supersedes and includes changes from #93 but refactored to use `ObjectKeeper`

There's a circular dependency on https://github.com/jolocom/sdk-storage-typeorm/pull/19