### PR TITLE
fix(issuer profile): attaching correct issuer data

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -162,7 +162,7 @@ export class CredentialKeeper
   async getCredentialType(cred: SignedCredential): Promise<CredentialType> {
     const metadata = await this.storage.get.credentialMetadata(cred)
 
-    if (!metadata.issuer) {
+    if (metadata.issuer) {
       try {
         metadata.issuer = await this.storage.get.publicProfile(cred.issuer)
       } catch(err) {


### PR DESCRIPTION
### Issue
when we get cred metadata from the storage the issuer property is a string. And previous condition of issuer presence on metadata would not resolve issue did to `IdentitySummary` and pass issuer as a string