### PR TITLE
chore(workflow): action to create pr in rnj

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -1,0 +1,23 @@
+name: 'Creating PR in "react-native-jolocom" repo'
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Create pull request
+      uses: SBub/create-outside-pr@v1.0.0
+
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      with:
+        destination_repo: 'jolocom/react-native-jolocom'
+        destination_base_branch: 'master'
+        user_name: 'SBub'
+        user_email: 'svetaibuben@gmail.com'


### PR DESCRIPTION
### Description
This workflow will create a PR in `react-native-jolocom` repo when new updates are pushed to master. The assumption is that when we make a new release we merge things to master (we should actually sync about it). The only role of this action is to pass inputs to the underlying action [SBub/create-outside-pr](https://github.com/SBub/create-outside-pr), which is adopted fork of another repo that creates PR using gh cli. `create-outside-pr` action looks at the `package.json` of the repo where the action was triggered, reads its name and version and creates PR in destination repo (in this case react-native-jolocom) in the format: `chore/bump-$PACKAGE_NAME-$PACAKGE_VERSION-$timestamp` with valid title and description.

### Purpose
Let `react-native-jolocom` know when updates happened to its jolocom ssi dependencies

### Further steps
We would have to use this action for jolocom-lib and sdk-storage repos, so this action can be further abstracted

[This PR in react-native-jolocom](https://github.com/jolocom/react-native-jolocom/pull/13) was generated with this action.  

