### PR TITLE
Resume interaction event

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -378,6 +378,11 @@ export class Agent {
       // JWTs
       await interxn.processInteractionToken(token)
       await this.storage.store.interactionToken(token)
+    } else if (interxn.lastMessage.encode() === jwt) {
+      // NOTE
+      // the @interactionResumed event is emitted here because @processInteractionToken is
+      // not called if the token was previously processed
+      this.interactionManager.emit('interactionResumed', interxn)
     }
 
     return interxn

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -362,11 +362,13 @@ export class Agent {
         .registrar.encounter(token.payload.pca)
     }
 
+    const lastJwt = interxn?.lastMessage.encode()
+
     if (!interxn) {
       // NOTE: interactionManager.start internally calls
       // processInteractionToken and storage.store
       interxn = await this.interactionManager.start(token, transportAPI)
-    } else if (interxn.lastMessage.encode() !== jwt) {
+    } else if (lastJwt !== jwt) {
       // NOTE FIXME TODO #multitenancy
       // we only process the message if it is not last message seen (see "else if" condition)
       // this is to allow for some flexibility with how processJWT is called,
@@ -378,7 +380,7 @@ export class Agent {
       // JWTs
       await interxn.processInteractionToken(token)
       await this.storage.store.interactionToken(token)
-    } else if (interxn.lastMessage.encode() === jwt) {
+    } else if (lastJwt === jwt) {
       // NOTE
       // the @interactionResumed event is emitted here because @processInteractionToken is
       // not called if the token was previously processed
@@ -699,12 +701,14 @@ export class Agent {
     await this.sdk.deleteAgent(this.idw.did, options)
   }
 
-
   public async export(opts?: ExportAgentOptions): Promise<IExportedAgent> {
     return this.sdk.exportAgent(this, opts)
   }
 
-  public async import(exagent: IExportedAgent, opts?: ExportAgentOptions): Promise<void> {
+  public async import(
+    exagent: IExportedAgent,
+    opts?: ExportAgentOptions,
+  ): Promise<void> {
     if (this.idw.did !== exagent.did) throw new SDKError(ErrorCode.Unknown)
     await this.sdk.importAgent(exagent, opts)
   }

--- a/src/interactionManager/interactionManager.ts
+++ b/src/interactionManager/interactionManager.ts
@@ -16,6 +16,7 @@ flows.forEach((f) => {
 export interface InteractionEvents {
   interactionCreated: (interxn: Interaction) => void
   interactionUpdated: (interxn: Interaction) => void
+  interactionResumed: (interxn: Interaction) => void
 }
 
 /**


### PR DESCRIPTION
With the addition of Deeplinks to the SmartWallet, we're relying on interaction events to show the interaction screens. As a result, we need an event that would inform us that an interaction message that was previously processed (but the interaction was canceled by the user) was processed again. This case is not handled by the `interactionCreated` event, since messages that were previously processed by the `Agent` are not processed by the `Interaction`.