### PR TITLE
Configure caching for identity resolution

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -171,14 +171,13 @@ export class CredentialTypeKeeper
     issuerDid = issuerDid || meta.issuer?.did
     fullCredType = this.getFullCredentialTypeList(fullCredType || meta.type)
 
-    if (!meta.issuer?.publicProfile) {
-      try {
-        meta.issuer = await this.storage.get.publicProfile(issuerDid)
-      } catch (err) {
-        console.error(`could not lookup issuer ${issuerDid}`, err)
-        // pass
-      }
+    try {
+      meta.issuer = await this.storage.get.publicProfile(issuerDid)
+    } catch (err) {
+      console.error(`could not lookup issuer ${issuerDid}`, err)
+      // pass
     }
+
     return new CredentialType(fullCredType, meta)
   }
 
@@ -216,7 +215,9 @@ export class CredentialTypeKeeper
           console.error('credential metadata import failed', credMeta, err)
           // TODO better error breakdown
           err =
+            // @ts-ignore
             err instanceof SDKError ? err : new SDKError(ErrorCode.Unknown, err)
+          // @ts-ignore
           rejected.push([credMeta, err])
         }
       }),
@@ -300,7 +301,9 @@ export class CredentialKeeper
           console.error('credential import failed', err)
           // TODO better error breakdown
           err =
+            // @ts-ignore
             err instanceof SDKError ? err : new SDKError(ErrorCode.Unknown, err)
+          // @ts-ignore
           rejected.push([credJson, err])
         }
       }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { FlowType } from './interactionManager/types'
 export interface IJolocomSDKConfig {
   storage: IStorage
   eventDB?: InternalDb
+  resolveCachedIdentities?: boolean
 }
 
 export interface IInitAgentOptions {
@@ -44,6 +45,7 @@ export class JolocomSDK {
   public transports = new TransportKeeper()
   public storage: IStorage
   public credentials: CredentialKeeper
+  public resolveCachedIdentities: boolean
 
   /**
    * The toplevel resolver which simply invokes {@link resolve}
@@ -58,6 +60,8 @@ export class JolocomSDK {
       conf.eventDB || this.storage.eventDB,
     )
     this.didMethods.register('jun', localDidMethod)
+
+    this.resolveCachedIdentities = conf.resolveCachedIdentities ?? true
 
     // FIXME the prefix bit is required just to match IResolver
     // but does anything need it at that level?
@@ -99,7 +103,7 @@ export class JolocomSDK {
   public async resolve(did: string): Promise<Identity> {
     const cached = await this.storage.get.identity(did)
 
-    if (!cached) {
+    if (!cached || !this.resolveCachedIdentities) {
       const resolved = await this.didMethods
         .getForDid(did)
         .resolver.resolve(did)

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,19 +103,19 @@ export class JolocomSDK {
   public async resolve(did: string): Promise<Identity> {
     const cached = await this.storage.get.identity(did)
 
-    if (!cached || !this.resolveCachedIdentities) {
-      const resolved = await this.didMethods
-        .getForDid(did)
-        .resolver.resolve(did)
-
-      await this.storage.store.identity(resolved).catch(err => {
-        console.error('Failed to store Identity after resolving', err)
-      })
-
-      return resolved
+    if (cached && this.resolveCachedIdentities) {
+      return cached
     }
 
-    return cached
+    const resolved = await this.didMethods
+      .getForDid(did)
+      .resolver.resolve(did)
+
+    await this.storage.store.identity(resolved).catch(err => {
+      console.error('Failed to store Identity after resolving', err)
+    })
+
+    return resolved
   }
 
   private _makePassStore(passOrStore?: string | IPasswordStore) {


### PR DESCRIPTION
In the SW we would like to be able to disable the usage of the identity cache when resolving identities, since it wouldn't update if a public profile was added or changed.